### PR TITLE
config: add port allocation

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -35,6 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=" \
     --label="org.nethserver.rootfull=1" \
     --label="org.nethserver.images=docker.io/crowdsecurity/crowdsec:v1.4.6-debian" \
+    --label="org.nethserver.tcp-ports-demand=2" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/actions/create-module/02create-first-configuration
+++ b/imageroot/actions/create-module/02create-first-configuration
@@ -10,4 +10,4 @@ set -e
 # build folder to store configuration
 mkdir -vp crowdsec_config
 # first build of the configuration
-expand-configuration
+exec expand-configuration

--- a/imageroot/actions/create-module/40bouncer-configuration
+++ b/imageroot/actions/create-module/40bouncer-configuration
@@ -30,7 +30,7 @@ f = open(os.environ["AGENT_STATE_DIR"]+"/secrets/bouncer_keys_firewall.secret")
 secret = f.read()
 f.close()
 
-ports = os.environ.get("TCP_PORTS", "").split(',')
+ports = os.environ["TCP_PORTS"].split(',')
 properties = {
     "secret": secret,
     "api_port": ports[0],

--- a/imageroot/actions/create-module/40bouncer-configuration
+++ b/imageroot/actions/create-module/40bouncer-configuration
@@ -30,11 +30,15 @@ f = open(os.environ["AGENT_STATE_DIR"]+"/secrets/bouncer_keys_firewall.secret")
 secret = f.read()
 f.close()
 
+ports = os.environ.get("TCP_PORTS", "").split(',')
 properties = {
-    "secret": secret
+    "secret": secret,
+    "api_port": ports[0],
+    "metrics_port": ports[1]
 }
 
 template = jenv.get_template('crowdsec-firewall-bouncer.yaml')
 output = template.render(properties)
+os.makedirs("/etc/crowdsec/bouncers", exist_ok = True) 
 with open("/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml","w") as f:
     f.write(output)

--- a/imageroot/actions/create-module/50start-bouncer
+++ b/imageroot/actions/create-module/50start-bouncer
@@ -26,7 +26,7 @@ install -v -m 644 "${tmpfile}" "/etc/systemd/system/crowdsec-firewall-bouncer.se
 
 # reload and start service
 systemctl daemon-reload
-systemctl enable --now crowdsec-firewall-bouncer.service
+
 # API server could be slow to start:
 # ignore  bouncer connect error if it fails to start on first run
-exit 0
+systemctl enable --now crowdsec-firewall-bouncer.service || exit 0

--- a/imageroot/actions/create-module/50start-bouncer
+++ b/imageroot/actions/create-module/50start-bouncer
@@ -26,8 +26,6 @@ install -v -m 644 "${tmpfile}" "/etc/systemd/system/crowdsec-firewall-bouncer.se
 
 # reload and start service
 systemctl daemon-reload
-# restart crowdsec so it listens on port 8085
-systemctl restart "${MODULE_ID}.service"
 systemctl enable --now crowdsec-firewall-bouncer.service
 # API server could be slow to start:
 # ignore  bouncer connect error if it fails to start on first run

--- a/imageroot/actions/create-module/50start-bouncer
+++ b/imageroot/actions/create-module/50start-bouncer
@@ -29,4 +29,4 @@ systemctl daemon-reload
 
 # API server could be slow to start:
 # ignore  bouncer connect error if it fails to start on first run
-systemctl enable --now crowdsec-firewall-bouncer.service || exit 0
+systemctl enable --now crowdsec-firewall-bouncer.service || :

--- a/imageroot/actions/destroy-module/55uninstall-bouncers
+++ b/imageroot/actions/destroy-module/55uninstall-bouncers
@@ -13,8 +13,10 @@ source /etc/os-release
 echo "Remove the bouncer:"
 if [[ "${PLATFORM_ID}" == "platform:el9" ]] ; then
     dnf remove -y crowdsec-firewall-bouncer-iptables
+    rm -fv /etc/yum.repos.d/crowdsec_crowdsec.repo
 elif [[ "${ID}" == "debian" ]]; then
     apt-get -y remove crowdsec-firewall-bouncer-iptables
+    rm -fv /etc/apt/sources.list.d/crowdsec_crowdsec.list
 else
     echo "The platform is not compatible, we exit"
     exit 0

--- a/imageroot/actions/destroy-module/60remove-firewalld-configuration
+++ b/imageroot/actions/destroy-module/60remove-firewalld-configuration
@@ -19,4 +19,7 @@ systemctl daemon-reload
 echo "Restart firewalld"
 systemctl restart firewalld
 
+# remove firewalld backup files
+rm -fv /etc/firewalld/ipsets/crowdsec*.xml.old
+
 exit 0

--- a/imageroot/actions/destroy-module/60remove-firewalld-configuration
+++ b/imageroot/actions/destroy-module/60remove-firewalld-configuration
@@ -12,7 +12,7 @@ firewall-cmd --permanent --delete-ipset=crowdsec6-blacklists
 firewall-cmd --permanent --delete-ipset=crowdsec-blacklists
 
 # remove our systemd unit override fragment
-rm -vf "/etc/systemd/system/crowdsec-firewall-bouncer.service.d/${MODULE_ID}-override.conf"
+rm -rvf "/etc/systemd/system/crowdsec-firewall-bouncer.service.d"
 systemctl daemon-reload
 
 # after IPSET deletion, we need to restart firewalld

--- a/imageroot/actions/destroy-module/60remove-firewalld-configuration
+++ b/imageroot/actions/destroy-module/60remove-firewalld-configuration
@@ -6,7 +6,6 @@
 #
 
 exec 1>&2 # Send any output to stderr, to not alter the action response protocol
-set -e
 
 echo "Remove ipset firewall rules"
 firewall-cmd --permanent --delete-ipset=crowdsec6-blacklists
@@ -19,3 +18,5 @@ systemctl daemon-reload
 # after IPSET deletion, we need to restart firewalld
 echo "Restart firewalld"
 systemctl restart firewalld
+
+exit 0

--- a/imageroot/actions/destroy-module/75remove-crowdsec-wrapper
+++ b/imageroot/actions/destroy-module/75remove-crowdsec-wrapper
@@ -9,6 +9,6 @@ exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 set -e
 
 # remove the wrapper to use the container
-
-rm -f /usr/local/sbin/cscli
-
+rm -vf /usr/local/sbin/cscli
+# remove residual config
+rm -rvf /etc/crowdsec

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -63,8 +63,8 @@ if os.path.isfile("crowdsec_config/config.yaml"):
         autoescape=select_autoescape(),
         keep_trailing_newline=True,
     )
-    # placeholder for later
-    properties = {}
+    ports = os.environ.get("TCP_PORTS", "").split(',')
+    properties = {"api_port": ports[0], "metrics_port": ports[1]}
 
     template = jenv.get_template('config.yaml')
     output = template.render(properties)

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -63,7 +63,7 @@ if os.path.isfile("crowdsec_config/config.yaml"):
         autoescape=select_autoescape(),
         keep_trailing_newline=True,
     )
-    ports = os.environ.get("TCP_PORTS", "").split(',')
+    ports = os.environ["TCP_PORTS"].split(',')
     properties = {"api_port": ports[0], "metrics_port": ports[1]}
 
     template = jenv.get_template('config.yaml')

--- a/imageroot/templates/config.yaml
+++ b/imageroot/templates/config.yaml
@@ -35,7 +35,7 @@ api:
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
     log_level: info
-    listen_uri: 0.0.0.0:8085
+    listen_uri: 127.0.0.1:{{api_port}}
     profiles_path: /etc/crowdsec/profiles.yaml
     trusted_ips: # IP ranges, or IPs which can have admin API access
       - 127.0.0.1
@@ -45,5 +45,5 @@ api:
 prometheus:
   enabled: true
   level: full
-  listen_addr: 0.0.0.0
-  listen_port: 6060
+  listen_addr: 127.0.0.1
+  listen_port: {{metrics_port}}

--- a/imageroot/templates/crowdsec-firewall-bouncer.yaml
+++ b/imageroot/templates/crowdsec-firewall-bouncer.yaml
@@ -9,7 +9,7 @@ log_compression: true
 log_max_size: 100
 log_max_backups: 3
 log_max_age: 30
-api_url: http://127.0.0.1:8085/
+api_url: http://127.0.0.1:{{api_port}}/
 api_key: {{secret}} 
 insecure_skip_verify: false
 disable_ipv6: false

--- a/tests/crowdsec.robot
+++ b/tests/crowdsec.robot
@@ -15,7 +15,7 @@ Check if crowdsec can be configured
     Should Be Equal As Integers    ${rc}  0
 
 Check if crowdsec works as expected
-    ${rc} =    Execute Command    exec 3<>/dev/tcp/127.0.0.1/8085
+    ${rc} =    Execute Command    exec 3<>/dev/tcp/127.0.0.1/${TCP_PORT}
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 


### PR DESCRIPTION
- the module allocates 2 TCP ports
- ports are expanded to config file, so crowdsec never listens to default port (8080)
- better cleanup on module removal