### PR TITLE
Better find the ipset created by firewalld

### DIFF
--- a/imageroot/bin/firewall-rules
+++ b/imageroot/bin/firewall-rules
@@ -7,10 +7,10 @@
 
 action=$1
 if [[ $action == 'create-ipset' ]]; then
-    if ! ipset list crowdsec-blacklists > /dev/null; then
+    if [[ ! -f /etc/firewalld/ipsets/crowdsec-blacklists.xml ]]; then
         firewall-cmd --permanent --new-ipset=crowdsec-blacklists --type=hash:ip --option="timeout=0" --option="maxelem=150000"
     fi
-    if ! ipset list crowdsec6-blacklists > /dev/null; then
+    if [[ ! -f  /etc/firewalld/ipsets/crowdsec6-blacklists.xml ]]; then
         firewall-cmd --permanent --new-ipset=crowdsec6-blacklists --option=family=inet6 --type=hash:ip --option="timeout=0" --option="maxelem=150000"
     fi
     firewall-cmd --reload


### PR DESCRIPTION
`ipset -L` or `ipset list ipsetName` could retun $? == 0 even if the set exists, we must use the file path created by firewall (same for debian and rhel)