### PR TITLE
Update crowdsec image version to v1.6.0-1-debian

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -34,7 +34,7 @@ buildah add "${container}" ui/dist /ui
 buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=" \
     --label="org.nethserver.rootfull=1" \
-    --label="org.nethserver.images=docker.io/crowdsecurity/crowdsec:v1.5.4-debian" \
+    --label="org.nethserver.images=docker.io/crowdsecurity/crowdsec:v1.6.0-1-debian" \
     --label="org.nethserver.tcp-ports-demand=2" \
     "${container}"
 # Commit the image


### PR DESCRIPTION
This pull request updates the crowdsec image version to v1.6.0-1-debian.

https://github.com/NethServer/dev/issues/6901