### PR TITLE
Enable the usage of X-Forwarded-For/X-Real-IP

### DIFF
--- a/imageroot/templates/config.yaml.local
+++ b/imageroot/templates/config.yaml.local
@@ -34,6 +34,7 @@ api:
     insecure_skip_verify: false
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
+    use_forwarded_for_headers: true
     log_level: info
     listen_uri: 127.0.0.1:{{api_port}}
     profiles_path: /etc/crowdsec/profiles.yaml


### PR DESCRIPTION
With roundcubemail we do not catch the real IP but the local ip for bad login 

`Mar 20 12:06:40 R4-pve.rocky9-pve4.org roundcubemail-app[790326]: errors: <48434fed> IMAP Error: Login failed for administrator@rocky9-pve4.org against R4-pve.rocky9-pve4.org from 10.0.2.100 (X-Real-IP: 192.168.13.25,X-Forwarded-For: 192.168.13.25). Could not connect to R4-pve.rocky9-pve4.org:143: Connection refused in /var/www/html/program/lib/Roundcube/rcube_imap.php on line 211 (POST /?_task=login&_action=login)`


https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#use_forwarded_for_headers