### PR TITLE
Use the redis replica for get smathost settings in service start

### DIFF
--- a/imageroot/bin/expand-smarthost
+++ b/imageroot/bin/expand-smarthost
@@ -16,7 +16,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 helo_host = os.environ.get("HELO_HOST", "")
 receiver_emails = os.environ.get("RECEIVER_EMAILS", "")
 
-smtp = agent.get_smarthost_settings(agent.redis_connect())
+smtp = agent.get_smarthost_settings(agent.redis_connect(use_replica=True))
 
 files =["crowdsec_config/notifications/email.yaml"]
 for f in files:


### PR DESCRIPTION
This pull request updates the smarthost settings in the agent.get_smarthost_settings() function to use a replica. This change ensures better performance and reliability in the application.


https://github.com/NethServer/dev/issues/6902