### PR TITLE
Add --privileged flag to podman run command

### DIFF
--- a/imageroot/crowdsec-firewall-bouncer.service
+++ b/imageroot/crowdsec-firewall-bouncer.service
@@ -32,8 +32,6 @@ ExecStart=/usr/bin/podman run \
     --uts=host \
     --network=host \
     --privileged \
-    --cap-add NET_ADMIN \
-    --cap-add NET_RAW \
     --volume  ./crowdsec_config/crowdsec-firewall-bouncer.yaml.local:/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml.local:Z \
     ${CROWDSEC_FIREWALL_BOUNCER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10

--- a/imageroot/crowdsec-firewall-bouncer.service
+++ b/imageroot/crowdsec-firewall-bouncer.service
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --uts=host \
     --network=host \
+    --privileged \
     --cap-add NET_ADMIN \
     --cap-add NET_RAW \
     --volume  ./crowdsec_config/crowdsec-firewall-bouncer.yaml.local:/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml.local:Z \


### PR DESCRIPTION
This pull request adds the --privileged flag to the podman run command in order to run the container with extended privileges. This is necessary for certain operations that require elevated permissions, such as manipulating network settings.

If we are not privileged we cannot create the set inside nftables

```
Apr 02 09:43:45 cstest.nr.nethserver.net crowdsec1-firewall-bouncer[10971]: time="2024-04-02T09:43:45Z" level=info msg="backend type : nftables"
Apr 02 09:43:45 cstest.nr.nethserver.net crowdsec1-firewall-bouncer[10971]: time="2024-04-02T09:43:45Z" level=fatal msg="conn.Receive: netlink receive: no such file or directory"
```

it seems when I tested without the flag privileged I did it on a machine where I first tested with a container and the flag privileged


https://github.com/NethServer/dev/issues/6900