### PR TITLE
Update crowdsec.service to include redis.service dependency

### DIFF
--- a/imageroot/crowdsec.service
+++ b/imageroot/crowdsec.service
@@ -10,7 +10,7 @@
 
 [Unit]
 Description=crowdsec server
-After=network.target
+After=network.target redis.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
This pull request updates the `crowdsec.service` file to include the `redis.service` dependency. This ensures that the `crowdsec` server starts after the `redis` service.

https://github.com/NethServer/dev/issues/6934