### PR TITLE
Update expand-smarthost script to use hostname as sender email 

### DIFF
--- a/imageroot/bin/expand-smarthost
+++ b/imageroot/bin/expand-smarthost
@@ -8,7 +8,6 @@
 import os
 import agent
 import agent.tasks
-import socket
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -35,7 +34,7 @@ if receiver_emails and smtp['enabled']:
         "smtp_username": smtp['username'],
         "smtp_password": smtp['password'],
         "smtp_port": smtp['port'],
-        "sender_email": smtp['username'] if smtp['username'] != "" else 'crowdsec@'+socket.gethostname(),
+        "sender_email": os.environ['MODULE_ID']+'@'+agent.get_hostname(),
         "receiver_emails": receiver_emails.split(","),
         "encryption_type": "none" if smtp['encrypt_smtp'] == "none" else "starttls" if smtp['encrypt_smtp'] == "starttls" else "ssltls",
         "auth_type": "login",

--- a/imageroot/bin/expand-smarthost
+++ b/imageroot/bin/expand-smarthost
@@ -6,10 +6,9 @@
 #
 
 import os
-import json
 import agent
 import agent.tasks
-import sys
+import socket
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -36,7 +35,7 @@ if receiver_emails and smtp['enabled']:
         "smtp_username": smtp['username'],
         "smtp_password": smtp['password'],
         "smtp_port": smtp['port'],
-        "sender_email": smtp['username'],
+        "sender_email": smtp['username'] if smtp['username'] != "" else 'crowdsec@'+socket.gethostname(),
         "receiver_emails": receiver_emails.split(","),
         "encryption_type": "none" if smtp['encrypt_smtp'] == "none" else "starttls" if smtp['encrypt_smtp'] == "starttls" else "ssltls",
         "auth_type": "login",


### PR DESCRIPTION
The expand-smarthost script has been updated to use the hostname as the sender email if no username is provided. This ensures that the sender email is always set, even if the username is not specified.

https://github.com/NethServer/dev/issues/6939