### PR TITLE
Quiet the log query done by the bouncer

### DIFF
--- a/imageroot/templates/config.yaml.local
+++ b/imageroot/templates/config.yaml.local
@@ -34,7 +34,7 @@ api:
     insecure_skip_verify: false
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
-    log_level: info
+    log_level: error # quiet the exchanges with the bouncers : GET /v1/decisions/stream
     listen_uri: 127.0.0.1:{{api_port}}
     profiles_path: /etc/crowdsec/profiles.yaml
     trusted_ips: # IP ranges, or IPs which can have admin API access


### PR DESCRIPTION
the log flood is repeated each 10 seconds, it comes from the get of the bouncer to know if he needs to  ban a decision

`Oct 15 10:39:13 R2-pve.rocky9-pve2.org crowdsec1[123878]: time="2024-10-15T08:39:13Z" level=info msg="127.0.0.1 - [Tue, 15 Oct 2024 08:39:13 UTC] \"GET /v1/decisions/stream HTTP/1.1 200 4.875875ms \"crowdsec-firewall-bouncer/v0.0.28-debian-pragmatic-af6e7e25822c2b1a02168b99ebbf8458bc6728e5\" \""`

also

`Oct 15 11:44:12 R2-pve.rocky9-pve2.org crowdsec2[136638]: time="2024-10-15T09:44:12Z" level=info msg="127.0.0.1 - [Tue, 15 Oct 2024 09:44:12 UTC] \"GET /v1/decisions/stream HTTP/1.1 200 5.020183ms \"crowdsec-firewall-bouncer/v0.0.28-debian-pragmatic-af6e7e25822c2b1a02168b99ebbf8458bc6728e5\" \""`

we can continue to see the `GET` by 

runagent -m crowdsec2 podman exec -ti crowdsec2 cscli metrics

![image](https://github.com/user-attachments/assets/789bd84b-b6de-42b9-b1c6-ea5f0acf4855)




Refs: https://github.com/NethServer/dev/issues/7062