### PR TITLE
fix(nethvoice): whitelist Queue Manager queue status check

### DIFF
--- a/imageroot/tainted/nethvoice-whitelist-http-probing.yaml
+++ b/imageroot/tainted/nethvoice-whitelist-http-probing.yaml
@@ -15,3 +15,4 @@ whitelist:
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/freepbx/rest/mobileapp/'
    - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/freepbx/rest/migration'
    - evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/janus/' # http code not provided
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/webrest/astproxy/qmanager_qstats/'


### PR DESCRIPTION
Request on /webrest/astproxy/qmanager_qstats/XXX are normal requests to check status of the queues, not a crawl.

```
Apr  1 09:51:09 nodo1 traefik[2707]: XX.XX.XX.XX - - [01/Apr/2025:07:51:09 +0000] "GET /webrest/astproxy/qmanager_qstats/940 HTTP/2.0" 200 381 "-" "-" 44580 "nethvoice1-cti-server-api-https@file" "http://127.0.0.1:20015" 4ms
Apr  1 09:51:09 nodo1 traefik[2707]: XX.XX.XX.XX - - [01/Apr/2025:07:51:09 +0000] "GET /webrest/astproxy/qmanager_qstats/941 HTTP/2.0" 200 381 "-" "-" 44581 "nethvoice1-cti-server-api-https@file" "http://127.0.0.1:20015" 5ms
...
Apr  1 09:51:09 nodo1 crowdsec3[297879]: time="2025-04-01T07:51:09Z" level=info msg="Ip XX.XX.XX.XX performed 'crowdsecurity/http-crawl-non_statics' (50 events over 6.993423407s) at 2025-04-01 07:51:09.179746224 +0000 UTC"
```

https://github.com/NethServer/dev/issues/7259