### PR TITLE
Add FreePBX configurations and parser to default installation

### DIFF
--- a/imageroot/actions/create-module/10initialize
+++ b/imageroot/actions/create-module/10initialize
@@ -43,7 +43,8 @@ podman exec -i ${MODULE_ID} cscli collections install \
     crowdsecurity/traefik \
     crowdsecurity/vsftpd \
     crowdsecurity/wordpress \
-    crowdsecurity/whitelist-good-actors
+    crowdsecurity/whitelist-good-actors \
+    crowdsecurity/asterisk
 
 # we need it if we want to ban with IP from country
 podman exec -i ${MODULE_ID} cscli parsers install crowdsecurity/geoip-enrich

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -157,3 +157,9 @@ if whitelists:
 os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True)
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
 shutil.copyfile("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml")
+# copy the freepbx parser and scenarios
+os.makedirs("crowdsec_config/parsers/s01-parse/crowdsecurity", exist_ok=True)
+os.makedirs("crowdsec_config/scenarios", exist_ok=True)
+shutil.copyfile("../tainted/freepbx-logs.yaml", "crowdsec_config/parsers/s01-parse/crowdsecurity/freepbx-logs.yaml")
+shutil.copyfile("../tainted/freepbx-user-enum.yaml", "crowdsec_config/scenarios/freepbx-user-enum.yaml")
+shutil.copyfile("../tainted/freepbx-bf.yaml", "crowdsec_config/scenarios/freepbx-bf.yaml")

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -158,8 +158,8 @@ os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
 shutil.copyfile("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml")
 # copy the freepbx parser and scenarios
-os.makedirs("crowdsec_config/parsers/s01-parse/crowdsecurity", exist_ok=True)
+os.makedirs("crowdsec_config/parsers/s01-parse", exist_ok=True)
 os.makedirs("crowdsec_config/scenarios", exist_ok=True)
-shutil.copyfile("../tainted/freepbx-logs.yaml", "crowdsec_config/parsers/s01-parse/crowdsecurity/freepbx-logs.yaml")
+shutil.copyfile("../tainted/freepbx-logs.yaml", "crowdsec_config/parsers/s01-parse/freepbx-logs.yaml")
 shutil.copyfile("../tainted/freepbx-user-enum.yaml", "crowdsec_config/scenarios/freepbx-user-enum.yaml")
 shutil.copyfile("../tainted/freepbx-bf.yaml", "crowdsec_config/scenarios/freepbx-bf.yaml")

--- a/imageroot/tainted/freepbx-bf.yaml
+++ b/imageroot/tainted/freepbx-bf.yaml
@@ -1,0 +1,27 @@
+type: leaky
+name: crowdsecurity/freepbx-bf
+description: "Detect freeswitch auth bruteforce"
+filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
+leakspeed: "10s"
+capacity: 5
+groupby: evt.Meta.source_ip
+blackhole: 1m
+reprocess: true
+labels:
+  service: freepbx
+  type: bruteforce
+  remediation: true
+
+---
+type: leaky
+name: crowdsecurity/freepbx-slow-bf
+description: "Detect freeswitch auth bruteforce"
+filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
+leakspeed: "1m"
+capacity: 20
+groupby: evt.Meta.source_ip
+blackhole: 1m
+labels:
+  service: freepbx
+  type: bruteforce
+  remediation: true

--- a/imageroot/tainted/freepbx-bf.yaml
+++ b/imageroot/tainted/freepbx-bf.yaml
@@ -1,5 +1,5 @@
 type: leaky
-name: crowdsecurity/freepbx-bf
+name: nethesis/freepbx-bf
 description: "Detect freeswitch auth bruteforce"
 filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
 leakspeed: "10s"
@@ -14,7 +14,7 @@ labels:
 
 ---
 type: leaky
-name: crowdsecurity/freepbx-slow-bf
+name: nethesis/freepbx-slow-bf
 description: "Detect freeswitch auth bruteforce"
 filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
 leakspeed: "1m"

--- a/imageroot/tainted/freepbx-bf.yaml
+++ b/imageroot/tainted/freepbx-bf.yaml
@@ -1,6 +1,6 @@
 type: leaky
 name: nethesis/freepbx-bf
-description: "Detect freeswitch auth bruteforce"
+description: "Detect freepbx auth bruteforce"
 filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
 leakspeed: "10s"
 capacity: 5
@@ -15,7 +15,7 @@ labels:
 ---
 type: leaky
 name: nethesis/freepbx-slow-bf
-description: "Detect freeswitch auth bruteforce"
+description: "Detect freepbx auth bruteforce"
 filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
 leakspeed: "1m"
 capacity: 20

--- a/imageroot/tainted/freepbx-logs.yaml
+++ b/imageroot/tainted/freepbx-logs.yaml
@@ -1,0 +1,26 @@
+name: crowdsecurity/freepbx-logs
+description: "Parse Freepbx logs"
+filter: "evt.Parsed.program startsWith 'freepbx'"
+onsuccess: next_stage
+pattern_syntax:
+  TIMESTAMP: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}'
+nodes:
+- grok:
+    pattern: '%{TIMESTAMP:timestamp}.*NOTICE.*:\d+ %{GREEDYDATA:parsedmessage}'
+    apply_on: message
+  nodes:
+  - grok:
+      pattern: '.*: Registration from ''<sip:%{USERNAME:username}@%{IPORHOST}>'' failed for ''%{IPORHOST:remote_ip}:\d+''.*'
+      apply_on: parsedmessage
+      statics:
+        - meta: sub_type
+          value: auth_failure
+        - meta: target_user
+          expression: evt.Parsed.username
+statics:
+    - meta: service
+      value: freepbx
+    - meta: source_ip
+      expression: evt.Parsed.source_ip
+    - target: evt.StrTime
+      expression: evt.Parsed.timestamp

--- a/imageroot/tainted/freepbx-logs.yaml
+++ b/imageroot/tainted/freepbx-logs.yaml
@@ -1,4 +1,4 @@
-name: crowdsecurity/freepbx-logs
+name: nethesis/freepbx-logs
 description: "Parse Freepbx logs"
 filter: "evt.Parsed.program startsWith 'freepbx'"
 onsuccess: next_stage

--- a/imageroot/tainted/freepbx-user-enum.yaml
+++ b/imageroot/tainted/freepbx-user-enum.yaml
@@ -1,5 +1,5 @@
 type: leaky
-name: crowdsecurity/freepbx_user_enum
+name: nethesis/freepbx_user_enum
 description: "Detect freepbx user enumeration bruteforce"
 filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
 distinct: evt.Meta.target_user

--- a/imageroot/tainted/freepbx-user-enum.yaml
+++ b/imageroot/tainted/freepbx-user-enum.yaml
@@ -1,0 +1,13 @@
+type: leaky
+name: crowdsecurity/freepbx_user_enum
+description: "Detect freepbx user enumeration bruteforce"
+filter: "evt.Meta.service startsWith 'freepbx' && evt.Meta.sub_type == 'auth_failure'"
+distinct: evt.Meta.target_user
+groupby: evt.Meta.source_ip
+leakspeed: 10s
+capacity: 5
+blackhole: 1m
+labels:
+  service: freepbx
+  type: bruteforce
+  remediation: true


### PR DESCRIPTION
Introduce FreePBX parser and scenarios for log parsing and bruteforce detection, enhancing security capabilities. Include 'crowdsecurity/asterisk' in default collections installation.


for testing 

```
root@rocky:/# cat asterisk.log 
[Dec 21 12:57:02] SECURITY[77]: res_security_log.c:114 security_event_stasis_cb: SecurityEvent="ChallengeResponseFailed",EventTV="2021-12-21T12:57:02.209+0000",Severity="Error",Service="PJSIP",EventVersion="1",AccountID="6001",SessionID="2kOigHiNhyip1cGGyzdgMkqKV9a0F_G7kVfGdCUA12qsTwyHlQox1T7LSWAX",LocalAddress="IPV4/UDP/172.17.0.2/5060",RemoteAddress="IPV4/UDP/172.17.0.1/54784",Challenge="1640091422/edc27724b23967f2cb58e348c4e578eb",Response="3b0bbeda2ac7623e8f39fd45cacd9ca0",ExpectedResponse=""
May 21 14:52:18 VoipNethvoice freepbx[349589]: [2025-05-21 14:52:18] NOTICE[150]: chan_sip.c:29058 handle_request_register: Registration from '<sip:5419@93.42.2.141>' failed for '137.184.125.78:51047' - Wrong password
May 21 14:52:18 VoipNethvoice freepbx[349589]: [2025-05-21 14:52:18] #033[1;33mNOTICE#033[0m[150]: #033[1;37mchan_sip.c#033[0m:#033[1;37m29058#033[0m #033[1;37mhandle_request_register#033[0m: Registration from '<sip:5419@93.42.2.141>' failed for '137.184.125.78:51047' - Wrong password
```


`cscli explain --file asterisk.log --type freepbx --verbose`

see [output](https://gist.github.com/stephdl/8a887aa314a97adf080f76a9b5c67859)

linked to https://github.com/nethesis/ns8-nethvoice/pull/455

discussion: https://mattermost.nethesis.it/nethesis/pl/fcctu79jfib1u8xutfguyqeqmc

Refs: https://github.com/NethServer/dev/issues/7481