### PR TITLE
whitelist freepbx extension reload

### DIFF
--- a/imageroot/tainted/nethvoice-whitelist-http-probing.yaml
+++ b/imageroot/tainted/nethvoice-whitelist-http-probing.yaml
@@ -14,5 +14,6 @@ whitelist:
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/freepbx/rest/nethlink'
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/freepbx/rest/mobileapp/'
    - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/freepbx/rest/migration'
+   - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'POST' && evt.Meta.http_path contains '/freepbx/rest/devices/phones/reload/'
    - evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/janus/' # http code not provided
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/webrest/astproxy/qmanager_qstats/'


### PR DESCRIPTION
Some log traces of freepbx are seen as bruteforce attack by the http-generic-403-bf  jail of crowdsec. For the log I have analysed it is the cause of the bans

```
Jun 05 22:19:40 n2nv8 traefik[2631628]: 195.231.86.171 - - [05/Jun/2025:20:19:40 +0000] "POST /freepbx/rest/devices/phones/reload/92200 HTTP/1.1" 403 0 "-" "-" 287864 "nethvoice12-wizard-https@file" "http://127.0.0.1:20152/" 65ms
Jun 05 22:19:40 n2nv8 freepbx[1334690]: 127.0.0.1 - - [05/Jun/2025:22:19:40 +0200] "POST /freepbx/rest/devices/phones/reload/92200 HTTP/1.1" 403 180 "-" "-"
Jun 05 22:19:40 n2nv8 traefik[2631628]: 195.231.86.171 - - [05/Jun/2025:20:19:40 +0000] "POST /freepbx/rest/devices/phones/reload/200 HTTP/1.1" 403 0 "-" "-" 287861 "nethvoice12-wizard-https@file" "http://127.0.0.1:20152/" 117ms
Jun 05 22:19:40 n2nv8 freepbx[1334690]: 127.0.0.1 - - [05/Jun/2025:22:19:40 +0200] "POST /freepbx/rest/devices/phones/reload/200 HTTP/1.1" 403 180 "-" "-"
Jun 05 22:19:40 n2nv8 freepbx[1334690]: 127.0.0.1 - - [05/Jun/2025:22:19:40 +0200] "POST /freepbx/rest/devices/phones/reload/200 HTTP/1.1" 403 180 "-" "-"
Jun 05 22:19:40 n2nv8 traefik[2631628]: 195.231.86.171 - - [05/Jun/2025:20:19:40 +0000] "POST /freepbx/rest/devices/phones/reload/200 HTTP/1.1" 403 0 "-" "-" 287863 "nethvoice12-wizard-https@file" "http://127.0.0.1:20152/" 109ms
Jun 05 22:19:40 n2nv8 traefik[2631628]: 195.231.86.171 - - [05/Jun/2025:20:19:40 +0000] "POST /freepbx/rest/devices/phones/reload/92200 HTTP/1.1" 403 0 "-" "-" 287862 "nethvoice12-wizard-https@file" "http://127.0.0.1:20152/" 128ms
Jun 05 22:19:40 n2nv8 freepbx[1334690]: 127.0.0.1 - - [05/Jun/2025:22:19:40 +0200] "POST /freepbx/rest/devices/phones/reload/92200 HTTP/1.1" 403 180 "-" "-"
Jun 05 22:19:40 n2nv8 kamailio[1920485]: 41(49) ERROR: nathelper [nathelper.c:1553]: sdp_1918(): Unable to parse sdp body
Jun 05 22:19:40 n2nv8 crowdsec2[320340]: time="2025-06-05T20:19:40Z" level=info msg="Ip 195.231.86.171 performed 'LePresidente/http-generic-403-bf' (6 events over 2.996021131s) at 2025-06-05 20:19:40.817754355 +0000 UTC"
Jun 05 22:19:40 n2nv8 kamailio[1920485]: 46(54) ERROR: nathelper [nathelper.c:1553]: sdp_1918(): Unable to parse sdp body
Jun 05 22:19:41 n2nv8 crowdsec2[320340]: time="2025-06-05T20:19:41Z" level=info msg="(localhost/crowdsec) LePresidente/http-generic-403-bf by ip 195.231.86.171 (IT/31034) : 192m ban on Ip 195.231.86.171"
Jun 05 22:19:41 n2nv8 rtpengine[1920393]: [1749154781.329810] WARNING: [106291033143482-21941486399999@93.69.91.50 port 17935]: [core] No support for kernel packet forwarding available (interface to kernel module not open)
Jun 05 22:19:41 n2nv8 nethvoice12[2259005]: 2025-06-05T20:19:41+00:00 - error: [controller_user] ReferenceError: param is not defined
```