### PR TITLE
Fix grok patterns for FreePBX log registration failures

### DIFF
--- a/imageroot/tainted/freepbx-logs.yaml
+++ b/imageroot/tainted/freepbx-logs.yaml
@@ -10,7 +10,15 @@ nodes:
     apply_on: message
   nodes:
   - grok:
-      pattern: '.*: Registration from ''<sip:%{USERNAME:username}@%{IPORHOST}>'' failed for ''%{IPORHOST:remote_ip}:\d+''.*'
+      pattern: '.*: Registration from ''<sip:%{USERNAME:username}@%{IPORHOST}>'' failed for ''%{IPORHOST:remote_ip}:%{NUMBER}''.*'
+      apply_on: parsedmessage
+      statics:
+        - meta: sub_type
+          value: auth_failure
+        - meta: target_user
+          expression: evt.Parsed.username
+  - grok:
+      pattern: '.*: Request ''REGISTER'' from ''<sip:%{USERNAME:username}@%{IPORHOST}>'' failed for ''%{IPORHOST:remote_ip}:%{NUMBER}''.*'
       apply_on: parsedmessage
       statics:
         - meta: sub_type


### PR DESCRIPTION
Update grok patterns to correctly capture registration failure messages in FreePBX logs.

https://github.com/NethServer/dev/issues/7481