### PR TITLE
Remove grok pattern for FreePBX registration failures with WireGuard VPN IP

### DIFF
--- a/imageroot/tainted/freepbx-logs.yaml
+++ b/imageroot/tainted/freepbx-logs.yaml
@@ -17,14 +17,6 @@ nodes:
           value: auth_failure
         - meta: target_user
           expression: evt.Parsed.username
-  - grok:
-      pattern: '.*: Request ''REGISTER'' from ''<sip:%{USERNAME:username}@%{IPORHOST}>'' failed for ''%{IPORHOST:source_ip}:%{NUMBER}''.*'
-      apply_on: parsedmessage
-      statics:
-        - meta: sub_type
-          value: auth_failure
-        - meta: target_user
-          expression: evt.Parsed.username
 statics:
     - meta: service
       value: freepbx


### PR DESCRIPTION
This PR removes the grok pattern for FreePBX registration failures with WireGuard VPN IPs because we cannot use the private VPN IPs to ban attackers with CrowdSec. We need their external public IPs, but those are not present in the logs.

https://github.com/NethServer/dev/issues/7481

see https://github.com/NethServer/dev/issues/7481#issuecomment-2990058160