### PR TITLE
Update crowdsec-firewall-bouncer to version 0.0.34

### DIFF
--- a/CHECKSUM
+++ b/CHECKSUM
@@ -1,1 +1,1 @@
-e4f6ed09fd9ce74117c2bc3db950326304cc741e1f6f532583d35b73a42dbad9  crowdsec-firewall-bouncer-linux-amd64.tgz
+8b07e08fb35a90b33eb2403eb93966679b39adb42c9cd03882de66cdf19a949f  crowdsec-firewall-bouncer-linux-amd64.tgz

--- a/build-images.sh
+++ b/build-images.sh
@@ -19,7 +19,7 @@ repobase="${REPOBASE:-ghcr.io/nethserver}"
 
 # The crowdsec-firewall-bouncer versions can be found : https://github.com/crowdsecurity/cs-firewall-bouncer/releases
 curl --netrc --fail -L -o crowdsec-firewall-bouncer-linux-amd64.tgz \
-    https://github.com/crowdsecurity/cs-firewall-bouncer/releases/download/v0.0.31/crowdsec-firewall-bouncer-linux-amd64.tgz
+    https://github.com/crowdsecurity/cs-firewall-bouncer/releases/download/v0.0.34/crowdsec-firewall-bouncer-linux-amd64.tgz
 
 # After updates add the new value to CHECKSUM file: sha256sum crowdsec-firewall-bouncer-linux-amd64.tgz > CHECKSUM
 sha256sum -c CHECKSUM


### PR DESCRIPTION
Refresh the download link and update the CHECKSUM for the new version of crowdsec-firewall-bouncer.

https://github.com/NethServer/dev/issues/7582