### PR TITLE
Fix ban duration format consistency

### DIFF
--- a/ui/src/views/Unban.vue
+++ b/ui/src/views/Unban.vue
@@ -288,7 +288,7 @@ export default {
         // 3h29m45s instead of 3h54m42.494246619s
         if (ban.decisions[0]) {
           const splitSecond = ban.decisions[0].duration.split(".");
-          ban.decisions[0].duration = splitSecond[0] + "s";
+          ban.decisions[0].duration = splitSecond[0];
           this.bans.push({
             duration: ban.decisions[0].duration,
             value: ban.decisions[0].value,


### PR DESCRIPTION
Remove the 's' from the ban duration format to ensure consistency in the display of durations.

see screenshot, we can see `s` twice for duration

<img width="963" height="280" alt="Capture d’écran du 2025-08-12 14-15-59" src="https://github.com/user-attachments/assets/5e6ca0d9-8336-4f02-a46b-b7a1f57e634d" />

https://github.com/NethServer/dev/issues/7582