### PR TITLE
Update Crowdsec image version and add environment variable

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -76,7 +76,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.max-per-node=1" \
     --label="org.nethserver.authorizations=" \
     --label="org.nethserver.rootfull=1" \
-    --label="org.nethserver.images=docker.io/crowdsecurity/crowdsec:v1.6.11-debian ${repobase}/crowdsec-firewall-bouncer:${IMAGETAG:-latest}" \
+    --label="org.nethserver.images=docker.io/crowdsecurity/crowdsec:v1.7.0-debian ${repobase}/crowdsec-firewall-bouncer:${IMAGETAG:-latest}" \
     --label="org.nethserver.tcp-ports-demand=2" \
     "${container}"
 # Commit the image

--- a/imageroot/crowdsec.service
+++ b/imageroot/crowdsec.service
@@ -35,6 +35,7 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --network=host \
     --env DISABLE_ONLINE_API=${DISABLE_ONLINE_API} \
+    --env CROWDSEC_SETUP_UNATTENDED_DISABLE=true \
     --volume  ./crowdsec_config:/etc/crowdsec:Z \
     --volume %N-data:/var/lib/crowdsec/data:Z \
     --volume ${CROWDSEC_JOURNAL}:/run/log/journal \


### PR DESCRIPTION
Update the Crowdsec image version to v1.7.0 in the build script and introduce the `CROWDSEC_SETUP_UNATTENDED_DISABLE` environment variable in the service configuration.