### PR TITLE
feat: add NethVoice-specific CrowdSec detection scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Then run the tool as
 Besides the CrowdSec hub collections, ns8-crowdsec ships custom, always-installed parsers/scenarios to detect:
 
 - HTTP brute-force and exploit-scan attacks against the NethVoice CTI middleware
+- Brute-force attacks against the NethVoice admin API login endpoint (`/freepbx/rest/login`)
 - SIP brute-force attacks against Kamailio authentication
 
 This is not a real CrowdSec hub collection (it won't show up with `cscli collections list`), so it is exposed as a single fake collection named `nethesis/nethvoice` through the `list-collections`/`toggle-collection` actions and the Collections page of the UI, backed by the `NETHVOICE_COLLECTION_ENABLED` flag (enabled by default).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ Then run the tool as
 - inspect a scenario: `cscli scenarios inspect crowdsecurity/ssh-bf`
 - inspect a parser: `cscli parsers inspect crowdsecurity/sshd-logs`
   
+## NethVoice / Kamailio scenarios
+
+Besides the CrowdSec hub collections, ns8-crowdsec ships custom, always-installed parsers/scenarios to detect:
+
+- HTTP brute-force and exploit-scan attacks against the NethVoice CTI middleware
+- SIP brute-force attacks against Kamailio authentication
+
+This is not a real CrowdSec hub collection (it won't show up with `cscli collections list`), so it is exposed as a single fake collection named `nethesis/nethvoice` through the `list-collections`/`toggle-collection` actions and the Collections page of the UI, backed by the `NETHVOICE_COLLECTION_ENABLED` flag (enabled by default).
+
+    api-cli run toggle-collection --agent module/crowdsec1 --data - <<EOF
+    {
+        "name": "nethesis/nethvoice",
+        "action": "remove"
+    }
+    EOF
+
 ## Instance enroll request
 
 You can see the metrics of crowdsec at https://app.crowdsec.net/, for this purpose you need to create a login for a single user or an organization in the website, then in the top right menu click in `enroll an instance` and retrieve the keys, then enroll your container and restart it.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Besides the CrowdSec hub collections, ns8-crowdsec ships custom, always-installe
 
 - HTTP brute-force and exploit-scan attacks against the NethVoice CTI middleware
 - Brute-force attacks against the NethVoice admin API login endpoint (`/freepbx/rest/login`)
+- Brute-force attacks against the NethVoice reports application login (`reports-api`)
 - SIP brute-force attacks against Kamailio authentication
 
 This is not a real CrowdSec hub collection (it won't show up with `cscli collections list`), so it is exposed as a single fake collection named `nethesis/nethvoice` through the `list-collections`/`toggle-collection` actions and the Collections page of the UI, backed by the `NETHVOICE_COLLECTION_ENABLED` flag (enabled by default).

--- a/imageroot/actions/create-module/03set-default-env-variables
+++ b/imageroot/actions/create-module/03set-default-env-variables
@@ -15,3 +15,4 @@ else:
     agent.set_env("CROWDSEC_JOURNAL", "/var/log/journal")
 
 agent.set_env("DISABLE_ONLINE_API", False)
+agent.set_env("NETHVOICE_COLLECTION_ENABLED", "True")

--- a/imageroot/actions/list-collections/10list-collections
+++ b/imageroot/actions/list-collections/10list-collections
@@ -10,7 +10,19 @@ set -e
 list=$(podman exec "$MODULE_ID" cscli collections list --all --output json)
 
 if [[ $list == 'null' ]]; then
-    echo '[]'
+    collections='[]'
 else
-    echo "$list" | jq '.collections // .'
+    collections=$(echo "$list" | jq '.collections // .')
 fi
+
+# nethesis/nethvoice is not a real CrowdSec hub collection: it bundles the
+# always-installed NethVoice and Kamailio custom parsers/scenarios, exposed
+# here as a single fake collection so it can be listed/toggled like the real
+# ones.
+status=$([[ "${NETHVOICE_COLLECTION_ENABLED:-True}" == "True" ]] && echo enabled || echo disabled)
+
+fake=$(jq -n --arg status "$status" '[
+{name: "nethesis/nethvoice", status: $status, description: "Detect brute-force and exploit-scan attacks against the NethVoice (SIP and HTTP)", local_version: "-", up_to_date: true, tainted: false}
+]')
+
+echo "$collections" | jq --argjson fake "$fake" '. + $fake'

--- a/imageroot/actions/toggle-collection/10toggle-collection
+++ b/imageroot/actions/toggle-collection/10toggle-collection
@@ -11,5 +11,16 @@ input=$(cat)
 name=$(echo "$input" | jq -r '.name')
 action=$(echo "$input" | jq -r '.action')
 
-podman exec "$MODULE_ID" cscli collections $action "$name"
-podman exec "$MODULE_ID" kill -HUP 1
+# nethesis/nethvoice is a fake collection bundling NethVoice and Kamailio
+# custom parsers/scenarios, toggled via an env flag instead of cscli
+case "$name" in
+    nethesis/nethvoice)
+        value=$([[ "$action" == "install" ]] && echo True || echo False)
+        python3 -c "import agent; agent.set_env('NETHVOICE_COLLECTION_ENABLED', '$value')"
+        systemctl reload "${MODULE_ID}.service"
+        ;;
+    *)
+        podman exec "$MODULE_ID" cscli collections $action "$name"
+        podman exec "$MODULE_ID" kill -HUP 1
+        ;;
+esac

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -168,9 +168,8 @@ if whitelists:
 os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True)
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
 
-# NethVoice and kamailio parsers/scenarios are exposed as fake collections
-# (nethesis/nethvoice, nethesis/kamailio) toggleable via toggle-collection.
-# A single flag controls both groups.
+# NethVoice and kamailio parsers/scenarios are exposed as a single fake
+# collection (nethesis/nethvoice) toggleable via toggle-collection.
 nethvoice_enabled = os.environ.get("NETHVOICE_COLLECTION_ENABLED", "True") == "True"
 
 nethvoice_files = [
@@ -178,6 +177,7 @@ nethvoice_files = [
     ("../tainted/nethvoice-middleware-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-middleware-logs.yaml"),
     ("../tainted/nethvoice-middleware-bf.yaml", "crowdsec_config/scenarios/nethvoice-middleware-bf.yaml"),
     ("../tainted/nethvoice-http-exploit-scan.yaml", "crowdsec_config/scenarios/nethvoice-http-exploit-scan.yaml"),
+    ("../tainted/nethvoice-admin-login-bf.yaml", "crowdsec_config/scenarios/nethvoice-admin-login-bf.yaml"),
     ("../tainted/kamailio-logs.yaml", "crowdsec_config/parsers/s01-parse/kamailio-logs.yaml"),
     ("../tainted/kamailio-bf.yaml", "crowdsec_config/scenarios/kamailio-bf.yaml"),
 ]

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -178,6 +178,8 @@ nethvoice_files = [
     ("../tainted/nethvoice-middleware-bf.yaml", "crowdsec_config/scenarios/nethvoice-middleware-bf.yaml"),
     ("../tainted/nethvoice-http-exploit-scan.yaml", "crowdsec_config/scenarios/nethvoice-http-exploit-scan.yaml"),
     ("../tainted/nethvoice-admin-login-bf.yaml", "crowdsec_config/scenarios/nethvoice-admin-login-bf.yaml"),
+    ("../tainted/nethvoice-reports-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-reports-logs.yaml"),
+    ("../tainted/nethvoice-reports-bf.yaml", "crowdsec_config/scenarios/nethvoice-reports-bf.yaml"),
     ("../tainted/kamailio-logs.yaml", "crowdsec_config/parsers/s01-parse/kamailio-logs.yaml"),
     ("../tainted/kamailio-bf.yaml", "crowdsec_config/scenarios/kamailio-bf.yaml"),
 ]

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -168,8 +168,11 @@ if whitelists:
 os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True)
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
 
-# NethVoice and kamailio parsers/scenarios are always installed, same as the
-# other tainted items above.
+# NethVoice and kamailio parsers/scenarios are exposed as fake collections
+# (nethesis/nethvoice, nethesis/kamailio) toggleable via toggle-collection.
+# A single flag controls both groups.
+nethvoice_enabled = os.environ.get("NETHVOICE_COLLECTION_ENABLED", "True") == "True"
+
 nethvoice_files = [
     ("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml"),
     ("../tainted/nethvoice-middleware-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-middleware-logs.yaml"),
@@ -180,8 +183,14 @@ nethvoice_files = [
 ]
 
 for src, dest in nethvoice_files:
-    os.makedirs(os.path.dirname(dest), exist_ok=True)
-    shutil.copyfile(src, dest)
+    if nethvoice_enabled:
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copyfile(src, dest)
+    else:
+        try:
+            os.remove(dest)
+        except FileNotFoundError:
+            pass
 
 # remove freepbx related custom parser and scenario as we don't support #7629
 files_to_remove = [

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -164,9 +164,24 @@ if whitelists:
             f.write(output)
 
 ## expand the tainted configuration files
+# nextcloud parser is always installed
 os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True)
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
-shutil.copyfile("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml")
+
+# NethVoice and kamailio parsers/scenarios are always installed, same as the
+# other tainted items above.
+nethvoice_files = [
+    ("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml"),
+    ("../tainted/nethvoice-middleware-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-middleware-logs.yaml"),
+    ("../tainted/nethvoice-middleware-bf.yaml", "crowdsec_config/scenarios/nethvoice-middleware-bf.yaml"),
+    ("../tainted/nethvoice-http-exploit-scan.yaml", "crowdsec_config/scenarios/nethvoice-http-exploit-scan.yaml"),
+    ("../tainted/kamailio-logs.yaml", "crowdsec_config/parsers/s01-parse/kamailio-logs.yaml"),
+    ("../tainted/kamailio-bf.yaml", "crowdsec_config/scenarios/kamailio-bf.yaml"),
+]
+
+for src, dest in nethvoice_files:
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    shutil.copyfile(src, dest)
 
 # remove freepbx related custom parser and scenario as we don't support #7629
 files_to_remove = [

--- a/imageroot/tainted/kamailio-bf.yaml
+++ b/imageroot/tainted/kamailio-bf.yaml
@@ -5,8 +5,13 @@ filter: "evt.Meta.log_type == 'kamailio_auth_fail'"
 groupby: "evt.Meta.source_ip"
 capacity: 5
 leakspeed: "10s"
-blackhole: 1m
+blackhole: "1m"
 labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "sip:bruteforce"
+  label: "Kamailio SIP brute force"
   service: sip
-  type: bruteforce
   remediation: true

--- a/imageroot/tainted/kamailio-bf.yaml
+++ b/imageroot/tainted/kamailio-bf.yaml
@@ -1,0 +1,12 @@
+type: leaky
+name: nethserver/kamailio-bf
+description: "Detect SIP login bruteforce on kamailio (nethvoice-proxy)"
+filter: "evt.Meta.log_type == 'kamailio_auth_fail'"
+groupby: "evt.Meta.source_ip"
+capacity: 5
+leakspeed: "10s"
+blackhole: 1m
+labels:
+  service: sip
+  type: bruteforce
+  remediation: true

--- a/imageroot/tainted/kamailio-logs.yaml
+++ b/imageroot/tainted/kamailio-logs.yaml
@@ -1,0 +1,15 @@
+onsuccess: next_stage
+debug: false
+filter: "evt.Parsed.program == 'kamailio'"
+name: nethserver/kamailio-logs
+description: "Parse kamailio failed SIP authentication events"
+grok:
+  pattern: '\[SECURITY-AUTHFAIL\] %{DATA:call_id} %{DATA:method}-%{DATA:cseq} - event=auth_failure method=%{WORD:sip_method} status=%{INT:sip_status} src_ip=%{IP:source_ip} user=%{DATA:auth_user} callid=%{DATA:sip_callid}'
+  apply_on: message
+statics:
+  - meta: log_type
+    value: kamailio_auth_fail
+  - meta: source_ip
+    expression: "evt.Parsed.source_ip"
+  - meta: service
+    value: kamailio

--- a/imageroot/tainted/nethvoice-admin-login-bf.yaml
+++ b/imageroot/tainted/nethvoice-admin-login-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-admin-login-bf
+description: "Detect brute force against the NethVoice admin API login endpoint"
+filter: "evt.Meta.service == 'http' && evt.Meta.http_path == '/freepbx/rest/login' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice admin API brute force"
+  service: nethvoice-admin
+  remediation: true

--- a/imageroot/tainted/nethvoice-http-exploit-scan.yaml
+++ b/imageroot/tainted/nethvoice-http-exploit-scan.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-http-exploit-scan
+description: "Detect scans for known FreePBX/NethVoice exploit paths regardless of scan pace"
+filter: "evt.Meta.service == 'http' && evt.Parsed.verb == 'POST' && evt.Meta.http_path in ['/admin/config.php'] && evt.Meta.http_status in ['308', '404']"
+groupby: evt.Meta.source_ip
+capacity: 5
+leakspeed: "15m"
+blackhole: "2h"
+labels:
+  confidence: 3
+  spoofable: 0
+  classification:
+    - attack.T1595
+  behavior: "http:scan"
+  label: "FreePBX exploit path scan"
+  service: http
+  remediation: true

--- a/imageroot/tainted/nethvoice-middleware-bf.yaml
+++ b/imageroot/tainted/nethvoice-middleware-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-middleware-bf
+description: "Detect brute force / token-guessing against nethcti-middleware API"
+filter: "evt.Meta.log_type == 'nethvoice_middleware_access-log' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice middleware brute force"
+  service: nethvoice-middleware
+  remediation: true

--- a/imageroot/tainted/nethvoice-middleware-logs.yaml
+++ b/imageroot/tainted/nethvoice-middleware-logs.yaml
@@ -1,0 +1,22 @@
+name: nethserver/nethvoice-middleware-logs
+description: "Parse nethcti-middleware (Gin) access and auth logs"
+filter: "evt.Parsed.program startsWith 'nethvoice'"
+onsuccess: next_stage
+nodes:
+  - grok:
+      pattern: '\[GIN\] %{DATA:gin_date} - %{DATA:gin_time} \| %{INT:status} \|\s*%{DATA:latency}\s*\|\s*%{IPORHOST:client_ip}\s*\| %{WORD:verb}\s*"%{DATA:path}"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: nethvoice_middleware_access-log
+        - meta: source_ip
+          expression: evt.Parsed.client_ip
+        - meta: http_status
+          expression: evt.Parsed.status
+        - meta: http_verb
+          expression: evt.Parsed.verb
+        - meta: http_path
+          expression: evt.Parsed.path
+statics:
+  - meta: service
+    value: nethvoice-middleware

--- a/imageroot/tainted/nethvoice-reports-bf.yaml
+++ b/imageroot/tainted/nethvoice-reports-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-reports-bf
+description: "Detect brute force / token-guessing against nethvoice reports API"
+filter: "evt.Meta.log_type == 'nethvoice_reports_access-log' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice reports brute force"
+  service: nethvoice-reports
+  remediation: true

--- a/imageroot/tainted/nethvoice-reports-logs.yaml
+++ b/imageroot/tainted/nethvoice-reports-logs.yaml
@@ -1,0 +1,22 @@
+name: nethserver/nethvoice-reports-logs
+description: "Parse nethvoice reports-api (Gin) access and auth logs"
+filter: "evt.Parsed.program == 'reports-api'"
+onsuccess: next_stage
+nodes:
+  - grok:
+      pattern: '\[GIN\] %{DATA:gin_date} - %{DATA:gin_time} \| %{INT:status} \|\s*%{DATA:latency}\s*\|\s*%{IPORHOST:client_ip}\s*\| %{WORD:verb}\s*"%{DATA:path}"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: nethvoice_reports_access-log
+        - meta: source_ip
+          expression: evt.Parsed.client_ip
+        - meta: http_status
+          expression: evt.Parsed.status
+        - meta: http_verb
+          expression: evt.Parsed.verb
+        - meta: http_path
+          expression: evt.Parsed.path
+statics:
+  - meta: service
+    value: nethvoice-reports


### PR DESCRIPTION
## Summary
- Add a parser (`nethvoice-middleware-logs.yaml`) for nethcti-middleware's Gin access/auth logs
- Add `nethvoice-middleware-bf.yaml`: detects low-and-slow brute-force/token-guessing against the middleware API (10m leaky window, since existing generic scenarios use a 10s window and miss this pace)
- Add `nethvoice-http-exploit-scan.yaml`: detects scans against known FreePBX exploit paths (`/admin/config.php`) regardless of pace, since existing `http-probing` requires a faster hit rate than observed real scans
- Add `kamailio-logs.yaml` + `kamailio-bf.yaml`: parses the new `SECURITY-AUTHFAIL` line kamailio now emits (nethvoice-proxy PR #193) and detects SIP login bruteforce (10s leaky window, capacity 5)
- Wire all new tainted files into `expand-configuration`, following the existing pattern used for `nethvoice-whitelist-http-probing.yaml`
- Add `nethvoice-admin-login-bf.yaml`: detects brute force against the NethVoice admin API login (`/freepbx/rest/login`)
- Add `nethvoice-reports-logs.yaml` + `nethvoice-reports-bf.yaml`: parses `reports-api` Gin logs and detects brute force against the reports app login
- Expose all of the above as a single fake collection `nethesis/nethvoice` in `list-collections`/`toggle-collection`, backed by `NETHVOICE_COLLECTION_ENABLED`, so it can be toggled from the Collections UI like a real collection
- Align `kamailio-bf.yaml` labels (confidence/classification/behavior) with the other brute-force scenarios for consistent alert display

Issue:
- NethServer/dev#7481
- NethServer/dev#8079

For the SIP part, require also: https://github.com/nethesis/ns8-nethvoice-proxy/pull/193

## Testing

Install: `add-module ghcr.io/nethserver/crowdsec:nethvoice_integration`
Update: `api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/crowdsec:nethvoice_integration","instances": "crowdsec1", "force": true}`