### PR TITLE
feat: protect NethVoice and Kamailio

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,30 @@ Then run the tool as
 - inspect a collection: `cscli collections inspect crowdsecurity/sshd`
 - inspect a scenario: `cscli scenarios inspect crowdsecurity/ssh-bf`
 - inspect a parser: `cscli parsers inspect crowdsecurity/sshd-logs`
-  
+
+## NethVoice / Kamailio scenarios
+
+Besides the CrowdSec hub collections, ns8-crowdsec ships custom parsers/scenarios to detect:
+
+- HTTP brute-force and exploit-scan attacks against the NethVoice CTI middleware
+- Brute-force attacks against the NethVoice admin API login endpoint (`/freepbx/rest/login`)
+- Brute-force attacks against the NethVoice reports application login (`reports-api`)
+- SIP brute-force attacks against Kamailio authentication
+
+These protections are enabled by default for new installations and can be enabled manually.
+For existing installations, the protections are disabled by default and can be enabled by setting the `NETHVOICE_COLLECTION_ENABLED=True` variable in the module's `.env` file:
+
+    runagent -m crowdsec1 bash -c 'echo "NETHVOICE_COLLECTION_ENABLED=True" >> .env'
+
+Then restart the module for changes to take effect:
+
+    systemctl restart crowdsec1
+
+To disable, remove the variable from `.env`, then restart:
+
+    runagent -m crowdsec1 bash -c 'sed -i "/NETHVOICE_COLLECTION_ENABLED/d" .env'
+    systemctl restart crowdsec1
+
 ## Instance enroll request
 
 You can see the metrics of crowdsec at https://app.crowdsec.net/, for this purpose you need to create a login for a single user or an organization in the website, then in the top right menu click in `enroll an instance` and retrieve the keys, then enroll your container and restart it.

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Besides the CrowdSec hub collections, ns8-crowdsec ships custom parsers/scenario
 - Brute-force attacks against the NethVoice reports application login (`reports-api`)
 - SIP brute-force attacks against Kamailio authentication
 
-These protections are enabled by default for new installations and can be enabled manually.
+These protections are enabled by default for new installations.
 For existing installations, the protections are disabled by default and can be enabled by setting the `NETHVOICE_COLLECTION_ENABLED=True` variable in the module's `.env` file:
 
-    runagent -m crowdsec1 bash -c 'echo "NETHVOICE_COLLECTION_ENABLED=True" >> .env'
+    runagent -m crowdsec1 python3 -c 'import agent ; agent.set_env("NETHVOICE_COLLECTION_ENABLED", "True")'
 
 Then restart the module for changes to take effect:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Then restart the module for changes to take effect:
 
 To disable, remove the variable from `.env`, then restart:
 
-    runagent -m crowdsec1 bash -c 'sed -i "/NETHVOICE_COLLECTION_ENABLED/d" .env'
+    runagent -m crowdsec1 python3 -c 'import agent ; agent.set_env("NETHVOICE_COLLECTION_ENABLED", "False")'
     systemctl restart crowdsec1
 
 ## Instance enroll request

--- a/imageroot/actions/create-module/03set-default-env-variables
+++ b/imageroot/actions/create-module/03set-default-env-variables
@@ -15,3 +15,4 @@ else:
     agent.set_env("CROWDSEC_JOURNAL", "/var/log/journal")
 
 agent.set_env("DISABLE_ONLINE_API", False)
+agent.set_env("NETHVOICE_COLLECTION_ENABLED", True)

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -160,7 +160,32 @@ if whitelists:
 ## expand the tainted configuration files
 os.makedirs("crowdsec_config/hub/parsers/s01-parse/crowdsecurity", exist_ok=True)
 shutil.copyfile("../tainted/nextcloud-logs.yaml", "crowdsec_config/hub/parsers/s01-parse/crowdsecurity/nextcloud-logs.yaml")
-shutil.copyfile("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml")
+
+# NethVoice and kamailio parsers/scenarios are exposed as a single fake
+# collection (nethesis/nethvoice) toggleable via toggle-collection.
+nethvoice_enabled = os.environ.get("NETHVOICE_COLLECTION_ENABLED", "False") == "True"
+
+nethvoice_files = [
+    ("../tainted/nethvoice-whitelist-http-probing.yaml", "crowdsec_config/parsers/s02-enrich/nethvoice-whitelist-http-probing.yaml"),
+    ("../tainted/nethvoice-middleware-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-middleware-logs.yaml"),
+    ("../tainted/nethvoice-middleware-bf.yaml", "crowdsec_config/scenarios/nethvoice-middleware-bf.yaml"),
+    ("../tainted/nethvoice-http-exploit-scan.yaml", "crowdsec_config/scenarios/nethvoice-http-exploit-scan.yaml"),
+    ("../tainted/nethvoice-admin-login-bf.yaml", "crowdsec_config/scenarios/nethvoice-admin-login-bf.yaml"),
+    ("../tainted/nethvoice-reports-logs.yaml", "crowdsec_config/parsers/s01-parse/nethvoice-reports-logs.yaml"),
+    ("../tainted/nethvoice-reports-bf.yaml", "crowdsec_config/scenarios/nethvoice-reports-bf.yaml"),
+    ("../tainted/kamailio-logs.yaml", "crowdsec_config/parsers/s01-parse/kamailio-logs.yaml"),
+    ("../tainted/kamailio-bf.yaml", "crowdsec_config/scenarios/kamailio-bf.yaml"),
+]
+
+for src, dest in nethvoice_files:
+    if nethvoice_enabled:
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copyfile(src, dest)
+    else:
+        try:
+            os.remove(dest)
+        except FileNotFoundError:
+            pass
 
 # remove freepbx related custom parser and scenario as we don't support #7629
 files_to_remove = [

--- a/imageroot/tainted/kamailio-bf.yaml
+++ b/imageroot/tainted/kamailio-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/kamailio-bf
+description: "Detect SIP login bruteforce on kamailio (nethvoice-proxy)"
+filter: "evt.Meta.log_type == 'kamailio_auth_fail'"
+groupby: "evt.Meta.source_ip"
+capacity: 5
+leakspeed: "10s"
+blackhole: "1m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "sip:bruteforce"
+  label: "Kamailio SIP brute force"
+  service: sip
+  remediation: true

--- a/imageroot/tainted/kamailio-logs.yaml
+++ b/imageroot/tainted/kamailio-logs.yaml
@@ -1,0 +1,15 @@
+onsuccess: next_stage
+debug: false
+filter: "evt.Parsed.program == 'kamailio'"
+name: nethserver/kamailio-logs
+description: "Parse kamailio failed SIP authentication events"
+grok:
+  pattern: '\[SECURITY-AUTHFAIL\] %{DATA:call_id} %{DATA:method}-%{DATA:cseq} - event=auth_failure method=%{WORD:sip_method} status=%{INT:sip_status} src_ip=%{IP:source_ip} user=%{DATA:auth_user} callid=%{DATA:sip_callid}'
+  apply_on: message
+statics:
+  - meta: log_type
+    value: kamailio_auth_fail
+  - meta: source_ip
+    expression: "evt.Parsed.source_ip"
+  - meta: service
+    value: kamailio

--- a/imageroot/tainted/nethvoice-admin-login-bf.yaml
+++ b/imageroot/tainted/nethvoice-admin-login-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-admin-login-bf
+description: "Detect brute force against the NethVoice admin API login endpoint"
+filter: "evt.Meta.service == 'http' && evt.Meta.http_path == '/freepbx/rest/login' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice admin API brute force"
+  service: nethvoice-admin
+  remediation: true

--- a/imageroot/tainted/nethvoice-http-exploit-scan.yaml
+++ b/imageroot/tainted/nethvoice-http-exploit-scan.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-http-exploit-scan
+description: "Detect scans for known FreePBX/NethVoice exploit paths regardless of scan pace"
+filter: "evt.Meta.service == 'http' && evt.Parsed.verb == 'POST' && evt.Meta.http_path in ['/admin/config.php'] && evt.Meta.http_status in ['308', '404']"
+groupby: evt.Meta.source_ip
+capacity: 5
+leakspeed: "15m"
+blackhole: "2h"
+labels:
+  confidence: 3
+  spoofable: 0
+  classification:
+    - attack.T1595
+  behavior: "http:scan"
+  label: "FreePBX exploit path scan"
+  service: http
+  remediation: true

--- a/imageroot/tainted/nethvoice-middleware-bf.yaml
+++ b/imageroot/tainted/nethvoice-middleware-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-middleware-bf
+description: "Detect brute force / token-guessing against nethcti-middleware API"
+filter: "evt.Meta.log_type == 'nethvoice_middleware_access-log' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice middleware brute force"
+  service: nethvoice-middleware
+  remediation: true

--- a/imageroot/tainted/nethvoice-middleware-logs.yaml
+++ b/imageroot/tainted/nethvoice-middleware-logs.yaml
@@ -1,0 +1,22 @@
+name: nethserver/nethvoice-middleware-logs
+description: "Parse nethcti-middleware (Gin) access and auth logs"
+filter: "evt.Parsed.program startsWith 'nethvoice'"
+onsuccess: next_stage
+nodes:
+  - grok:
+      pattern: '\[GIN\] %{DATA:gin_date} - %{DATA:gin_time} \| %{INT:status} \|\s*%{DATA:latency}\s*\|\s*%{IPORHOST:client_ip}\s*\| %{WORD:verb}\s*"%{DATA:path}"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: nethvoice_middleware_access-log
+        - meta: source_ip
+          expression: evt.Parsed.client_ip
+        - meta: http_status
+          expression: evt.Parsed.status
+        - meta: http_verb
+          expression: evt.Parsed.verb
+        - meta: http_path
+          expression: evt.Parsed.path
+statics:
+  - meta: service
+    value: nethvoice-middleware

--- a/imageroot/tainted/nethvoice-reports-bf.yaml
+++ b/imageroot/tainted/nethvoice-reports-bf.yaml
@@ -1,0 +1,17 @@
+type: leaky
+name: nethserver/nethvoice-reports-bf
+description: "Detect brute force / token-guessing against nethvoice reports API"
+filter: "evt.Meta.log_type == 'nethvoice_reports_access-log' && evt.Meta.http_status in ['401', '403']"
+groupby: evt.Meta.source_ip
+capacity: 8
+leakspeed: "10m"
+blackhole: "15m"
+labels:
+  confidence: 2
+  spoofable: 0
+  classification:
+    - attack.T1110
+  behavior: "http:bruteforce"
+  label: "NethVoice reports brute force"
+  service: nethvoice-reports
+  remediation: true

--- a/imageroot/tainted/nethvoice-reports-logs.yaml
+++ b/imageroot/tainted/nethvoice-reports-logs.yaml
@@ -1,0 +1,22 @@
+name: nethserver/nethvoice-reports-logs
+description: "Parse nethvoice reports-api (Gin) access and auth logs"
+filter: "evt.Parsed.program == 'reports-api'"
+onsuccess: next_stage
+nodes:
+  - grok:
+      pattern: '\[GIN\] %{DATA:gin_date} - %{DATA:gin_time} \| %{INT:status} \|\s*%{DATA:latency}\s*\|\s*%{IPORHOST:client_ip}\s*\| %{WORD:verb}\s*"%{DATA:path}"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: nethvoice_reports_access-log
+        - meta: source_ip
+          expression: evt.Parsed.client_ip
+        - meta: http_status
+          expression: evt.Parsed.status
+        - meta: http_verb
+          expression: evt.Parsed.verb
+        - meta: http_path
+          expression: evt.Parsed.path
+statics:
+  - meta: service
+    value: nethvoice-reports

--- a/imageroot/update-module.d/03set-default-env-variables
+++ b/imageroot/update-module.d/03set-default-env-variables
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+# Set NETHVOICE_COLLECTION_ENABLED to False only if not already set
+if "NETHVOICE_COLLECTION_ENABLED" not in os.environ:
+    agent.set_env("NETHVOICE_COLLECTION_ENABLED", False)


### PR DESCRIPTION
Add parsers/scenarios covering:

- HTTP brute-force and exploit-scan attacks against the NethVoice CTI middleware
- Brute-force attacks against the NethVoice admin API login endpoint (/freepbx/rest/login)
- Brute-force attacks against the NethVoice reports application login (reports-api)
- SIP brute-force attacks against Kamailio authentication

These protections are disabled by default on existing installations. Enable by setting NETHVOICE_COLLECTION_ENABLED=True in the module's .env file.

Issues:
- NethServer/dev#7481
- NethServer/dev#8079

Related PRs:
- for the SIP part, require also: https://github.com/nethesis/ns8-nethvoice-proxy/pull/193
- replace: https://github.com/NethServer/ns8-crowdsec/pull/181

Code to be integrated inside `feature/alerts-collections` branch available inside `nethvoice/expose-toggle-fake-collections`

## Testing

Install: `add-module ghcr.io/nethserver/crowdsec:crowdsec-nethvoice-kamailio-detections`
Update: `api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/crowdsec:crowdsec-nethvoice-kamailio-detection": "crowdsec1", "force": true}`