### PR TITLE
feat: expose NethVoice/Kamailio scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Besides the CrowdSec hub collections, ns8-crowdsec ships custom parsers/scenario
 - SIP brute-force attacks against Kamailio authentication
 
 These protections are enabled by default for new installations.
-For existing installations, the protections are disabled by default and can be enabled by setting the `NETHVOICE_COLLECTION_ENABLED=True` variable in the module's `.env` file:
+For existing installations, the protections are disabled by default and can be managed from the Web interface.
+
+From CLI, the protection can be enabled/disabled by setting the `NETHVOICE_COLLECTION_ENABLED=True` variable in the module's `.env` file:
 
     runagent -m crowdsec1 python3 -c 'import agent ; agent.set_env("NETHVOICE_COLLECTION_ENABLED", "True")'
 

--- a/imageroot/actions/list-collections/10list-collections
+++ b/imageroot/actions/list-collections/10list-collections
@@ -10,7 +10,19 @@ set -e
 list=$(podman exec "$MODULE_ID" cscli collections list --all --output json)
 
 if [[ $list == 'null' ]]; then
-    echo '[]'
+    collections='[]'
 else
-    echo "$list" | jq '.collections // .'
+    collections=$(echo "$list" | jq '.collections // .')
 fi
+
+# nethesis/nethvoice is not a real CrowdSec hub collection: it bundles the
+# always-installed NethVoice and Kamailio custom parsers/scenarios, exposed
+# here as a single fake collection so it can be listed/toggled like the real
+# ones.
+status=$([[ "${NETHVOICE_COLLECTION_ENABLED:-True}" == "True" ]] && echo enabled || echo disabled)
+
+fake=$(jq -n --arg status "$status" '[
+{name: "nethesis/nethvoice", status: $status, description: "Local rules: detect brute-force and exploit-scan attacks against NethVoice application (SIP and HTTP)", local_version: "-", up_to_date: true, tainted: false}
+]')
+
+echo "$collections" | jq --argjson fake "$fake" '. + $fake'

--- a/imageroot/actions/toggle-collection/10toggle-collection
+++ b/imageroot/actions/toggle-collection/10toggle-collection
@@ -11,5 +11,16 @@ input=$(cat)
 name=$(echo "$input" | jq -r '.name')
 action=$(echo "$input" | jq -r '.action')
 
-podman exec "$MODULE_ID" cscli collections $action "$name"
-podman exec "$MODULE_ID" kill -HUP 1
+# nethesis/nethvoice is a fake collection bundling NethVoice and Kamailio
+# custom parsers/scenarios, toggled via an env flag instead of cscli
+case "$name" in
+    nethesis/nethvoice)
+        value=$([[ "$action" == "install" ]] && echo True || echo False)
+        python3 -c "import agent; agent.set_env('NETHVOICE_COLLECTION_ENABLED', '$value')"
+        systemctl reload "${MODULE_ID}.service"
+        ;;
+    *)
+        podman exec "$MODULE_ID" cscli collections $action "$name"
+        systemctl reload "${MODULE_ID}.service"
+        ;;
+esac


### PR DESCRIPTION
list-collections/toggle-collection actions surface nethesis/nethvoice as a fake collection (backed by NETHVOICE_COLLECTION_ENABLED, defaulted in create-module) so the always-installed custom parsers/scenarios can be seen and toggled from the Collections UI even though they are not a real CrowdSec hub collection.

expand-configuration installs/removes the corresponding tainted parser and scenario files based on the flag. Depends on the tainted files introduced by the NethVoice/Kamailio detection scenarios work.

Replaces https://github.com/NethServer/ns8-crowdsec/pull/183